### PR TITLE
Add same-proximity sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,23 @@ command! -bang -nargs=? -complete=dir Files
   \ call fzf#vim#files(<q-args>, {'source': s:list_cmd(),
   \                               'options': '--tiebreak=index'}, <bang>0)
 ```
+
+Paths of the same proximity are output in an arbitrary order by default:
+
+```console
+$ echo "banana\napple/pie\napple" | proximity-sort .
+> banana
+> apple
+> apple/pie
+```
+
+You may enable alphabetic sorting of the groups of same-proximity paths, at the
+expense of performance, by passing `-s` or `--sort-same-proximity` to
+`proximity-sort`, like so:
+
+```console
+$ echo "banana\napple/pie\napple" | proximity-sort . -s
+> apple
+> banana
+> apple/pie
+```

--- a/README.md
+++ b/README.md
@@ -62,18 +62,7 @@ command! -bang -nargs=? -complete=dir Files
   \                               'options': '--tiebreak=index'}, <bang>0)
 ```
 
-Paths of the same proximity are output in an arbitrary order by default:
-
-```console
-$ echo "banana\napple/pie\napple" | proximity-sort .
-> banana
-> apple
-> apple/pie
-```
-
-You may enable alphabetic sorting of the groups of same-proximity paths, at the
-expense of performance, by passing `-s` or `--sort-same-proximity` to
-`proximity-sort`, like so:
+Paths of the same proximity are sorted alphabetically:
 
 ```console
 $ echo "banana\napple/pie\napple" | proximity-sort . -s

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ impl Ord for Line {
     fn cmp(&self, other: &Self) -> Ordering {
         self.score
             .cmp(&other.score)
-            .then_with(|| other.path.cmp(&self.path))
+            .then_with(|| OsStr::from_bytes(&other.path).cmp(&OsStr::from_bytes(&self.path)))
     }
 }
 


### PR DESCRIPTION
Today is the first time I've touched Rust, so please bear with me :smile: Wanted to implement it with a streaming iterator, holding the heap in its struct and generating the next set only when the current one is depleted, but Rust won. If you wish, you can have a go at it, but the current implementation should be good enough, and it doesn't impact the existing code. Let me know if changes are needed.