### PR TITLE
Remove badges as they are deprecated on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,5 @@ repository = "https://github.com/jonhoo/proximity-sort.git"
 keywords = ["cli", "pipe", "filter", "utility"]
 categories = ["command-line-utilities"]
 
-[badges]
-travis-ci = { repository = "jonhoo/proximity-sort" }
-maintenance = { status = "passively-maintained" }
-
 [dependencies]
 clap = "2.32"


### PR DESCRIPTION
While they are not _technically_ deprecated in the `Cargo.toml` manifest itself, they are not being shown anymore and the intention seems pretty clear to remove them from the manifest itself at some point.

Relevant: https://github.com/rust-lang/crates.io/pull/2440