### PR TITLE
replace deprecated method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
-os_str_bytes = { version = "6.4", features = ["raw_os_str"], default-features = false }
+os_str_bytes = { version = "6.4", features = ["raw_os_str", "conversions"], default-features = false }
 
 [profile.release]
 lto = "yes"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ where
     for (i, line) in input.into_iter().enumerate() {
         let mut missed = false;
         let mut path = path.iter();
-        let os_str = RawOsStr::assert_from_raw_bytes(&line);
+        let os_str = RawOsStr::assert_cow_from_raw_bytes(&line);
         let os_str = os_str.to_os_str();
         let proximity = Path::new(&os_str)
             .components()


### PR DESCRIPTION
Replaced deprecated  method `os_str_bytes::RawOsStr::assert_from_raw_bytes` with `os_str_bytes::RawOsStr::assert_cow_from_raw_bytes`